### PR TITLE
Allow plugins to cache data to share between runs

### DIFF
--- a/WASM_PLUGINS.md
+++ b/WASM_PLUGINS.md
@@ -39,10 +39,16 @@ record in the wit file for details. Treetags passes in the the file path of the
 source code file relative to project root, the value of `--kinds-{lang}` cli
 argument passed by the user (`lang` is picked up from the TOML file supplied as
 part of the plugin), value of `extras` cli argument and value of `fields` cli
-argument passed by the user. The plugin is expected to return an array of the
-`tag` record described in the wit file as well as a string containing description
-of any errors. The WASM plugin gets access to the systems `stderr` stream and
-nothing else on the system.
+argument passed by the user and optionally a `cache-file` to presist data for
+subsequent runs of treetags on the same source code file. The plugin is
+expected to return an array of the `tag` record described in the wit file as
+well as a string containing description of any errors. The WASM plugin gets
+access to the systems `stderr` stream and nothing else on the system by default.
+When the user passes the `--plugin-cache` CLI argument the plugin also gets
+access to a per project cache directory for persisting data inbetween runs.
+This can enable the plugin to implement functionality like incremental parsing.
+The `cache-file` passed to generate is unique per project for each source code
+file.
 
 ### `plugin.toml` file
 

--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,15 @@ fn main() {
     compile_test_grammars(Path::new(&out_dir));
     build_wasm_plugins(Path::new(&out_dir));
 
+    // Empty plugins dir for tests to use to isolate themselves from the host
+    // system default plugins dir
+    let empty_plugins_dir = Path::new(&out_dir).join("empty-plugins-dir");
+    fs::create_dir_all(&empty_plugins_dir).unwrap();
+    println!(
+        "cargo:rustc-env=TREETAGS_TEST_EMPTY_PLUGINS_DIR={}",
+        empty_plugins_dir.display()
+    );
+
     let test_cases = discover_test_cases();
 
     // Generate individual test files

--- a/plugins/common/src/lib.rs
+++ b/plugins/common/src/lib.rs
@@ -1,7 +1,7 @@
 /// ABI version implemented by this SDK version.
 /// Must match `PLUGIN_ABI_VERSION` in the treetags host (`src/plugin/mod.rs`).
 /// Bump this (and the host constant) whenever the WIT interface changes.
-pub const ABI_VERSION: u32 = 2;
+pub const ABI_VERSION: u32 = 3;
 
 pub mod tag_config;
 pub use tag_config::TagKindConfig;

--- a/plugins/echo/plugin.toml
+++ b/plugins/echo/plugin.toml
@@ -1,4 +1,4 @@
 name = "echo"
 version = "0.2.0"
-abi_version = 2
+abi_version = 3
 extensions = ["echo"]

--- a/plugins/echo/src/lib.rs
+++ b/plugins/echo/src/lib.rs
@@ -8,7 +8,11 @@ use exports::treetags::plugin::plugin::{Guest, Request, Tag};
 struct EchoPlugin;
 
 impl Guest for EchoPlugin {
-    fn generate(_req: Request, _source: Vec<u8>) -> Result<Vec<Tag>, String> {
+    fn generate(req: Request, _source: Vec<u8>) -> Result<Vec<Tag>, String> {
+        if let Some(cache_name) = req.cache_file {
+            std::fs::write(&cache_name, "echo_cache_written\n")
+                .map_err(|e| format!("cache write error: {e}"))?;
+        }
         Ok(vec![Tag {
             name: "echo_tag".into(),
             line: 1,

--- a/plugins/java/plugin.toml
+++ b/plugins/java/plugin.toml
@@ -1,6 +1,6 @@
 name = "java"
 version = "0.2.0"
-abi_version = 2
+abi_version = 3
 extensions = ["java"]
 language = "java"
 

--- a/src/bin/build_plugin.rs
+++ b/src/bin/build_plugin.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 
 /// ABI version written into the distributed plugin.toml.
 /// Keep in sync with PLUGIN_ABI_VERSION in src/plugin/mod.rs.
-const PLUGIN_ABI_VERSION: u32 = 2;
+const PLUGIN_ABI_VERSION: u32 = 3;
 
 #[derive(Parser)]
 #[command(

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,13 @@ pub struct Config {
     #[arg(long = "plugin-dir", value_name = "PATH")]
     pub plugin_dirs: Vec<std::path::PathBuf>,
 
+    /// Grants a plugin read/write access to a per-source-file cache file under
+    /// ~/.cache/treetags/<project-hash>/<plugin-name>/. Specify the `name` field
+    /// from the plugin's plugin.toml.
+    /// Can be repeated to allow cache file access for multiple files
+    #[arg(long = "plugin-cache", value_name = "NAME")]
+    pub plugin_cache: Vec<String>,
+
     /// Directory to search recursively for WASM plugins. Defaults to ~/.config/treetags/plugins.
     #[arg(long = "plugins-dir", value_name = "PATH")]
     pub plugins_dir_arg: Option<std::path::PathBuf>,

--- a/src/config/paths.rs
+++ b/src/config/paths.rs
@@ -20,3 +20,15 @@ pub fn get_config_path() -> PathBuf {
 pub fn get_default_plugins_dir() -> PathBuf {
     get_treetags_dir().join("plugins")
 }
+
+pub fn get_cache_dir() -> PathBuf {
+    match xdg::BaseDirectories::with_prefix("treetags") {
+        Ok(xdg_dirs) => xdg_dirs.get_cache_home(),
+        Err(_) => {
+            let mut path = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+            path.push(".cache");
+            path.push("treetags");
+            path
+        }
+    }
+}

--- a/src/language_parser.rs
+++ b/src/language_parser.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::builtin_langs::{BuiltinLangDesc, BUILTIN_LANG_DESCRIPTORS};
@@ -19,12 +20,15 @@ use crate::tag::Tag;
 /// parsing state lives in the per-thread `Parser` passed to `generate_tags`.
 pub trait LanguageParser: Send + Sync {
     /// Generate tags by delegating to the per-thread `Parser` engine.
+    /// `absolute_path` is the source file's absolute path, used by WASM plugins
+    /// for cache file naming; ignored by builtin and query parsers.
     fn generate_tags(
         &self,
         parser: &mut Parser,
         code: &[u8],
         path: &str,
         config: &Config,
+        absolute_path: &Path,
     ) -> Vec<Tag>;
 
     /// Kind metadata for `--list-kinds`. Never requires a `Parser`.
@@ -69,6 +73,7 @@ impl LanguageParser for BuiltinLanguageParser {
         code: &[u8],
         path: &str,
         config: &Config,
+        _absolute_path: &Path,
     ) -> Vec<Tag> {
         (self.generate_fn)(&mut parser.ts_parser, code, path, &self.kind_config, config)
             .unwrap_or_default()
@@ -100,9 +105,10 @@ impl LanguageParser for WasmLanguageParser {
         code: &[u8],
         path: &str,
         config: &Config,
+        absolute_path: &Path,
     ) -> Vec<Tag> {
         parser
-            .try_plugin(&self.extension, code, path, config)
+            .try_plugin(&self.extension, code, path, config, absolute_path)
             .unwrap_or_default()
     }
 
@@ -130,6 +136,7 @@ impl LanguageParser for QueryLanguageParser {
         code: &[u8],
         path: &str,
         _config: &Config,
+        _absolute_path: &Path,
     ) -> Vec<Tag> {
         parser.generate_by_tag_query(code, path, &self.extension)
     }
@@ -168,6 +175,7 @@ impl LanguageParserRegistry {
         let plugin_registry = Arc::new(PluginRegistry::scan(
             &config.plugin_dirs,
             Some(&config.plugins_dir),
+            &config.plugin_cache,
         ));
 
         let mut map: HashMap<String, Box<dyn LanguageParser>> = HashMap::new();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -130,12 +130,14 @@ impl Parser {
         code: &[u8],
         path: &str,
         config: &Config,
+        absolute_path: &std::path::Path,
     ) -> Option<Vec<tag::Tag>> {
         self.shared_registry.as_ref()?.try_generate(
             &mut self.local_instances,
             extension,
             code,
             path,
+            absolute_path,
             config,
         )
     }
@@ -211,9 +213,13 @@ impl Parser {
             .map_err(|e| format!("Failed to read file '{}': {}", file_path, e))?;
 
         // Priority 1: WASM plugin
-        if let Some(tags) =
-            self.try_plugin(extension, &code, file_path_relative_to_tag_file, config)
-        {
+        if let Some(tags) = self.try_plugin(
+            extension,
+            &code,
+            file_path_relative_to_tag_file,
+            config,
+            std::path::Path::new(file_path),
+        ) {
             return Ok(tags);
         }
 

--- a/src/plugin/instance.rs
+++ b/src/plugin/instance.rs
@@ -1,5 +1,7 @@
+use std::path::Path;
 use wasmtime::component::{Component, Linker, ResourceTable};
 use wasmtime::Store;
+use wasmtime_wasi::{DirPerms, FilePerms};
 
 wasmtime::component::bindgen!({
     world: "plugin-world",
@@ -50,11 +52,18 @@ impl WasmInstance {
     }
 }
 
-pub fn new_store(engine: &wasmtime::Engine) -> Store<PluginState> {
+pub fn new_store(engine: &wasmtime::Engine, cache_dir: Option<&Path>) -> Store<PluginState> {
+    let mut builder = wasmtime_wasi::WasiCtxBuilder::new();
+    builder.inherit_stderr();
+    if let Some(dir) = cache_dir {
+        if let Err(e) = std::fs::create_dir_all(dir) {
+            eprintln!("treetags: cannot create cache dir {}: {e}", dir.display());
+        } else if let Err(e) = builder.preopened_dir(dir, ".", DirPerms::all(), FilePerms::all()) {
+            eprintln!("treetags: cannot preopen cache dir {}: {e}", dir.display());
+        }
+    }
     let state = PluginState {
-        ctx: wasmtime_wasi::WasiCtxBuilder::new()
-            .inherit_stderr()
-            .build(),
+        ctx: builder.build(),
         table: ResourceTable::new(),
     };
     Store::new(engine, state)

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -10,4 +10,4 @@ pub use registry::PluginRegistry;
 /// ABI version this build of treetags accepts from WASM plugins.
 /// Bump this whenever the WIT interface (wit/treetags-plugin.wit) changes
 /// in a backwards-incompatible way, and update the constant in plugins/common.
-pub const PLUGIN_ABI_VERSION: u32 = 2;
+pub const PLUGIN_ABI_VERSION: u32 = 3;

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -6,7 +6,7 @@ use crate::split_by_newlines::split_by_newlines;
 use crate::tag::Tag;
 use indexmap::IndexMap;
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use wasmtime::Engine;
@@ -21,6 +21,7 @@ struct PluginEntry {
 struct ExtPlugin {
     wasm_path: PathBuf,
     language: Option<String>,
+    name: String,
 }
 
 /// Language name and file extensions for a detected plugin.
@@ -38,12 +39,22 @@ pub struct PluginRegistry {
     ext_plugins: HashMap<String, ExtPlugin>,
     compiled: HashMap<PathBuf, OnceLock<Option<SharedPlugin>>>,
     engine: Engine,
+    /// Plugins opted in for cache file access.
+    cache_enabled_plugins: HashSet<String>,
+    /// Per-project cache root: ~/.cache/treetags/<hash-of-cwd>/.
+    /// None when no plugins have cache access enabled.
+    project_cache_root: Option<PathBuf>,
 }
 
 impl PluginRegistry {
     /// Scans `dirs` for `plugin.toml` manifests. WASM binaries are JIT-compiled lazily
     /// on first use, at most once per unique `.wasm` file.
-    pub fn scan(dirs: &[PathBuf], recursive_dir: Option<&PathBuf>) -> Self {
+    /// `cache_plugins` is the list of plugin names granted cache file access.
+    pub fn scan(
+        dirs: &[PathBuf],
+        recursive_dir: Option<&PathBuf>,
+        cache_plugins: &[String],
+    ) -> Self {
         let entries = scan_to_entries(dirs, recursive_dir);
 
         let mut ext_plugins: HashMap<String, ExtPlugin> = HashMap::new();
@@ -58,15 +69,27 @@ impl PluginRegistry {
                 ExtPlugin {
                     wasm_path: entry.wasm_path.clone(),
                     language: entry.language.clone(),
+                    name: entry.name.clone(),
                 },
             );
         }
+
+        let cache_enabled_plugins: HashSet<String> = cache_plugins.iter().cloned().collect();
+        let project_cache_root = if cache_enabled_plugins.is_empty() {
+            None
+        } else {
+            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            let project_hash = format!("{:016x}", fnv1a_64(cwd.as_os_str().as_encoded_bytes()));
+            Some(crate::config::paths::get_cache_dir().join(project_hash))
+        };
 
         Self {
             entries,
             ext_plugins,
             compiled,
             engine: Engine::default(),
+            cache_enabled_plugins,
+            project_cache_root,
         }
     }
 
@@ -111,9 +134,18 @@ impl PluginRegistry {
         extension: &str,
         source: &[u8],
         file_path: &str,
+        absolute_path: &Path,
         config: &Config,
     ) -> Option<Vec<Tag>> {
         let ep = self.ext_plugins.get(extension)?;
+
+        let plugin_cache_dir: Option<PathBuf> = if self.cache_enabled_plugins.contains(&ep.name) {
+            self.project_cache_root
+                .as_ref()
+                .map(|root| root.join(&ep.name))
+        } else {
+            None
+        };
 
         // Lazily JIT-compile the plugin the first time a file with this extension is seen.
         // On failure the OnceLock stores None permanently — no retry, error printed once.
@@ -133,11 +165,12 @@ impl PluginRegistry {
             .as_ref()?;
 
         // Lazy-create a per-thread WasmInstance from the now-compiled shared plugin.
+        // The cache dir is preopened as "." in the plugin's WASI sandbox.
         let instance = match local_instances.entry(extension.to_string()) {
             Entry::Occupied(e) => e.into_mut(),
             Entry::Vacant(e) => {
                 let inst = shared
-                    .create_instance()
+                    .create_instance(plugin_cache_dir.as_deref())
                     .map_err(|e| eprintln!("treetags: plugin init error for .{extension}: {e}"))
                     .ok()?;
                 e.insert(inst)
@@ -150,11 +183,16 @@ impl PluginRegistry {
             .unwrap_or("")
             .to_string();
 
+        let cache_file = plugin_cache_dir
+            .as_ref()
+            .map(|_| cache_filename(absolute_path));
+
         let req = Request {
             file_path: file_path.to_string(),
             kinds,
             extras: config.extras.clone(),
             fields: config.fields.clone(),
+            cache_file,
         };
 
         match instance.generate(&req, source) {
@@ -172,6 +210,26 @@ impl PluginRegistry {
             }
         }
     }
+}
+
+/// FNV-1a 64-bit hash — deterministic across runs, no new dependencies.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    const BASIS: u64 = 14695981039346656037;
+    const PRIME: u64 = 1099511628211;
+    let mut h = BASIS;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(PRIME);
+    }
+    h
+}
+
+/// Returns the cache filename for a source file: a 16-hex-digit FNV-1a hash + ".cache".
+fn cache_filename(abs_path: &Path) -> String {
+    format!(
+        "{:016x}.cache",
+        fnv1a_64(abs_path.as_os_str().as_encoded_bytes())
+    )
 }
 
 /// Per-extension plugin metadata, returned without loading any WASM.
@@ -197,7 +255,7 @@ pub fn scan_ext_infos(dirs: &[PathBuf], plugins_dir: Option<&PathBuf>) -> Vec<Pl
 /// Prints a formatted table of all detected plugins to stdout.
 pub fn print_plugin_list(dirs: &[PathBuf], plugins_dir: &PathBuf) {
     println!("Plugin directory: {}", plugins_dir.display());
-    let registry = PluginRegistry::scan(dirs, Some(plugins_dir));
+    let registry = PluginRegistry::scan(dirs, Some(plugins_dir), &[]);
     let plugins = registry.list_plugins();
     if plugins.is_empty() {
         println!("No plugins detected.");
@@ -407,7 +465,7 @@ mod tests {
             r#"
 name = "plugin-a"
 version = "0.1.0"
-abi_version = 2
+abi_version = 3
 wasm_file = "plugin.wasm"
 extensions = ["a"]
 "#,
@@ -420,7 +478,7 @@ extensions = ["a"]
             r#"
 name = "plugin-b"
 version = "0.1.0"
-abi_version = 2
+abi_version = 3
 wasm_file = "plugin.wasm"
 extensions = ["b"]
 "#,
@@ -428,7 +486,7 @@ extensions = ["b"]
         .unwrap();
         fs::write(plugin_b.join("plugin.wasm"), "").unwrap();
 
-        let registry = PluginRegistry::scan(&[], Some(&dir.path().to_path_buf()));
+        let registry = PluginRegistry::scan(&[], Some(&dir.path().to_path_buf()), &[]);
         assert!(registry.entries.contains_key("a"));
         assert!(registry.entries.contains_key("b"));
         assert_eq!(registry.entries.len(), 2);
@@ -445,7 +503,7 @@ extensions = ["b"]
             r#"
 name = "java-plugin"
 version = "0.1.0"
-abi_version = 2
+abi_version = 3
 wasm_file = "plugin.wasm"
 language = "java"
 extensions = ["java", "class"]
@@ -454,7 +512,7 @@ extensions = ["java", "class"]
         .unwrap();
         fs::write(plugin_java.join("plugin.wasm"), "").unwrap();
 
-        let registry = PluginRegistry::scan(&[], Some(&dir.path().to_path_buf()));
+        let registry = PluginRegistry::scan(&[], Some(&dir.path().to_path_buf()), &[]);
         let plugins = registry.list_plugins();
         assert_eq!(plugins.len(), 1);
         assert_eq!(plugins[0].language, "java");
@@ -471,7 +529,7 @@ extensions = ["java", "class"]
             r#"
 name = "my-plugin"
 version = "0.1.0"
-abi_version = 2
+abi_version = 3
 wasm_file = "plugin.wasm"
 extensions = ["xyz"]
 "#,
@@ -479,7 +537,7 @@ extensions = ["xyz"]
         .unwrap();
         fs::write(dir.path().join("plugin.wasm"), "").unwrap();
 
-        let registry = PluginRegistry::scan(&[dir.path().to_path_buf()], None);
+        let registry = PluginRegistry::scan(&[dir.path().to_path_buf()], None, &[]);
         let plugins = registry.list_plugins();
         assert_eq!(plugins.len(), 1);
         assert_eq!(plugins[0].language, "my-plugin");

--- a/src/plugin/shared.rs
+++ b/src/plugin/shared.rs
@@ -32,8 +32,9 @@ impl SharedPlugin {
 
     /// Creates a new per-thread execution context (own linear memory, own call stack).
     /// The compiled component code is shared — no re-JIT per thread.
-    pub fn create_instance(&self) -> anyhow::Result<WasmInstance> {
-        let store = new_store(&self.engine);
+    /// Pass `cache_dir` to preopen a directory for the plugin's cache files.
+    pub fn create_instance(&self, cache_dir: Option<&Path>) -> anyhow::Result<WasmInstance> {
+        let store = new_store(&self.engine, cache_dir);
         WasmInstance::from_component(store, &self.component, &self.linker)
     }
 }

--- a/src/tag_processor.rs
+++ b/src/tag_processor.rs
@@ -116,7 +116,8 @@ impl TagProcessor {
                 }
             };
 
-            let mut tags = lp.generate_tags(&mut parser, &code, &file_path_relative, &config);
+            let mut tags =
+                lp.generate_tags(&mut parser, &code, &file_path_relative, &config, &file_path);
 
             if let Ok(mut guard) = tags_lock.lock() {
                 guard.append(&mut tags);

--- a/tests/helpers/golden_test_runner.rs
+++ b/tests/helpers/golden_test_runner.rs
@@ -100,12 +100,23 @@ grammar_lib_path = "{}"
     Ok(())
 }
 
-/// Execute the treetags command with given arguments
+/// Execute the treetags command with given arguments.
+/// Prepends `--plugins-dir <empty>` when the test args don't already specify
+/// `--plugins-dir`, so that the user's global ~/.config/treetags/plugins
+/// directory is never consulted during tests.
+/// Tests that need specific plugins use `--plugin-dir` (explicit), which is
+/// additive and unaffected by `--plugins-dir`.
 fn execute_command(working_dir: &Path, args: &[String]) -> Result<std::process::Output, String> {
-    Command::cargo_bin("treetags")
-        .map_err(|e| format!("Failed to create command: {}", e))?
-        .current_dir(working_dir)
-        .args(args)
+    let has_plugins_dir = args.iter().any(|a| a == "--plugins-dir")
+        || args.iter().any(|a| a.starts_with("--plugins-dir="));
+
+    let mut cmd =
+        Command::cargo_bin("treetags").map_err(|e| format!("Failed to create command: {}", e))?;
+    cmd.current_dir(working_dir);
+    if !has_plugins_dir {
+        cmd.args(["--plugins-dir", env!("TREETAGS_TEST_EMPTY_PLUGINS_DIR")]);
+    }
+    cmd.args(args)
         .output()
         .map_err(|e| format!("Failed to execute command: {}", e))
 }

--- a/tests/test_cases/plugin/basic/input/args.txt
+++ b/tests/test_cases/plugin/basic/input/args.txt
@@ -1,1 +1,1 @@
---plugin-dir {TREETAGS_TEST_PLUGINS_DIR} -f - source.echo
+--plugin-dir {TREETAGS_TEST_PLUGINS_DIR} -f - --plugin-cache echo source.echo

--- a/wit/treetags-plugin.wit
+++ b/wit/treetags-plugin.wit
@@ -4,10 +4,15 @@ package treetags:plugin@1.0.0;
 interface plugin {
     /// Input passed from treetags to the plugin for each file.
     record request {
-        file-path: string,
-        kinds:     string,
-        extras:    string,
-        fields:    string,
+        file-path:  string,
+        kinds:      string,
+        extras:     string,
+        fields:     string,
+        /// Filename of the cache file for this source file. For use when
+        /// plugins want to persist some information in between runs for say
+        /// incremental compilation or other reasons
+        /// None when the plugin has not been granted cache access by the user.
+        cache-file: option<string>,
     }
 
     /// A single tag returned by the plugin.


### PR DESCRIPTION
Implemented primarily to allow plugins to explore incremental compilation.
The functionality will continue to be a part of treetags if plugins leverage it.
May be removed in the future to reduce complexity and maintainenance burden if
no usage is reported for the functionality.