### PR TITLE
Remove IndexMap dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Removed `IndexMap` dependency
+
 - [0.12.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,7 +2250,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "dirs",
- "indexmap",
  "libloading",
  "predicates 2.1.5",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ wasmtime-wasi = "45"
 clap = { version = "4.5.27", features = ["derive", "string"] }
 clap_complete = "4.5"
 dirs = "6.0.0"
-indexmap = "2.0"
 libloading = "0.9.0"
 rayon = "1"
 regex = "1.11.1"

--- a/src/parser/cpp.rs
+++ b/src/parser/cpp.rs
@@ -710,8 +710,11 @@ fn process_declaration(
             }
             // Function declarator - handle function prototypes
             "function_declarator" => {
-                let fn_name =
-                    extract_function_name_from_declarator(cursor, context, &mut ExtensionFields::new());
+                let fn_name = extract_function_name_from_declarator(
+                    cursor,
+                    context,
+                    &mut ExtensionFields::new(),
+                );
                 if !fn_name.is_empty() {
                     let mut proto_fields = ExtensionFields::new();
                     if !type_info.is_empty() {

--- a/src/parser/cpp.rs
+++ b/src/parser/cpp.rs
@@ -1,5 +1,5 @@
 use super::helper::{self, iterate_children, Break, Continue, LanguageContext, TagKindConfig};
-use indexmap::IndexMap;
+use crate::tag::ExtensionFields;
 use tree_sitter::{Node, TreeCursor};
 
 use crate::tag;
@@ -144,8 +144,8 @@ impl<'a> CppContext<'a> {
     }
 
     // Build extension fields based on the current scope stack
-    fn create_extension_fields(&self) -> IndexMap<String, String> {
-        let mut fields = IndexMap::new();
+    fn create_extension_fields(&self) -> ExtensionFields {
+        let mut fields = ExtensionFields::new();
         let mut namespace_path = Vec::new();
 
         for (scope_type, name) in &self.scope_stack {
@@ -229,7 +229,7 @@ fn create_tag(
     kind_char: &str,
     node: Node,
     context: &mut CppContext,
-    extra_fields: Option<IndexMap<String, String>>,
+    extra_fields: Option<ExtensionFields>,
 ) {
     if name.is_empty() || name == "_" {
         return;
@@ -241,7 +241,7 @@ fn create_tag(
 
     let row = node.start_position().row;
     let address = helper::address_string_from_line(row, &context.base);
-    let mut extension_fields = IndexMap::new();
+    let mut extension_fields = ExtensionFields::new();
 
     // 1. Kind field (k)
     if context
@@ -491,7 +491,7 @@ fn process_union(cursor: &mut TreeCursor, context: &mut CppContext) -> Option<(S
 fn process_enum(cursor: &mut TreeCursor, context: &mut CppContext) -> Option<(ScopeType, String)> {
     let node = cursor.node();
     let mut enum_name = String::new();
-    let mut extra_fields = IndexMap::new();
+    let mut extra_fields = ExtensionFields::new();
     let mut enum_values = Vec::new();
 
     iterate_children!(cursor, |child_node| {
@@ -542,7 +542,7 @@ fn process_enum(cursor: &mut TreeCursor, context: &mut CppContext) -> Option<(Sc
 
         // Create tags for enum values
         for (value_name, value_node) in enum_values {
-            let mut value_fields = IndexMap::new();
+            let mut value_fields = ExtensionFields::new();
             value_fields.insert("enum".to_string(), enum_name.clone());
             create_tag(value_name, "e", value_node, context, Some(value_fields));
         }
@@ -558,7 +558,7 @@ fn process_function_definition(
     context: &mut CppContext,
 ) -> Option<(ScopeType, String)> {
     let node = cursor.node();
-    let mut extra_fields = IndexMap::new();
+    let mut extra_fields = ExtensionFields::new();
     let mut fn_name = String::new();
 
     iterate_children!(cursor, |child_node| {
@@ -613,7 +613,7 @@ fn process_function_definition(
 fn extract_function_name_from_declarator(
     cursor: &mut TreeCursor,
     context: &mut CppContext,
-    extra_fields: &mut IndexMap<String, String>,
+    extra_fields: &mut ExtensionFields,
 ) -> String {
     let mut fn_name = String::new();
 
@@ -711,9 +711,9 @@ fn process_declaration(
             // Function declarator - handle function prototypes
             "function_declarator" => {
                 let fn_name =
-                    extract_function_name_from_declarator(cursor, context, &mut IndexMap::new());
+                    extract_function_name_from_declarator(cursor, context, &mut ExtensionFields::new());
                 if !fn_name.is_empty() {
-                    let mut proto_fields = IndexMap::new();
+                    let mut proto_fields = ExtensionFields::new();
                     if !type_info.is_empty() {
                         proto_fields.insert("typeref".to_string(), type_info.clone());
                     }
@@ -786,7 +786,7 @@ fn process_declaration(
                 "v"
             };
 
-            let mut extra_fields = IndexMap::new();
+            let mut extra_fields = ExtensionFields::new();
 
             if !type_info.is_empty() {
                 extra_fields.insert("typeref".to_string(), type_info.clone());
@@ -875,7 +875,7 @@ fn process_field_declaration(
     });
 
     if !field_name.is_empty() {
-        let mut extra_fields = IndexMap::new();
+        let mut extra_fields = ExtensionFields::new();
 
         if !type_info.is_empty() {
             let typeref_value = if is_pointer {
@@ -948,7 +948,7 @@ fn process_macro_function_definition(
                     match params_child.kind() {
                         "identifier" => {
                             let param_name = context.base.node_text(&params_child).to_string();
-                            let mut fields = IndexMap::new();
+                            let mut fields = ExtensionFields::new();
                             fields.insert("macro".to_string(), macro_name.clone());
                             create_tag(param_name, "D", params_child, context, Some(fields));
                             Continue
@@ -1039,7 +1039,7 @@ fn process_typedef(
         type_info = format!("struct:{}", anon_name);
     }
 
-    let mut extra_fields = IndexMap::new();
+    let mut extra_fields = ExtensionFields::new();
     if !type_info.is_empty() {
         extra_fields.insert("typeref".to_string(), type_info);
     }
@@ -1289,7 +1289,7 @@ fn process_parameter_list(cursor: &mut TreeCursor, context: &mut CppContext, fn_
             });
 
             if !name.is_empty() {
-                let mut extra_fields = IndexMap::new();
+                let mut extra_fields = ExtensionFields::new();
                 match context.scope_stack.last() {
                     Some((ScopeType::Class, class_name)) => extra_fields.insert(
                         "function".to_string(),

--- a/src/parser/go.rs
+++ b/src/parser/go.rs
@@ -1,5 +1,5 @@
 use super::helper::{self, Context, LanguageContext, TagKindConfig};
-use indexmap::IndexMap;
+use crate::tag::ExtensionFields;
 use tree_sitter::TreeCursor;
 
 use crate::tag;
@@ -62,10 +62,10 @@ fn create_extension_fields_with_language(
     kind_char: &str,
     row: usize,
     node: tree_sitter::Node,
-    extra_fields: Option<IndexMap<String, String>>,
-) -> Option<IndexMap<String, String>> {
+    extra_fields: Option<ExtensionFields>,
+) -> Option<ExtensionFields> {
     let field_order = get_field_order_for_go();
-    let mut extension_fields = IndexMap::new();
+    let mut extension_fields = ExtensionFields::new();
 
     // Process fields in the preferred order
     for &field_name in &field_order {
@@ -205,8 +205,8 @@ impl<'a> GoContext<'a> {
     }
 
     // Build extension fields based on the current scope stack
-    fn create_extension_fields(&self) -> IndexMap<String, String> {
-        let mut fields = IndexMap::new();
+    fn create_extension_fields(&self) -> ExtensionFields {
+        let mut fields = ExtensionFields::new();
 
         for (scope_type, name) in &self.scope_stack {
             match scope_type {
@@ -246,7 +246,7 @@ impl<'a> GoContext<'a> {
         name: String,
         kind_char: &str,
         node: tree_sitter::Node,
-        extra_fields: Option<IndexMap<String, String>>,
+        extra_fields: Option<ExtensionFields>,
     ) {
         if name.is_empty() || name == "_" {
             return; // Don't tag empty or placeholder names
@@ -357,7 +357,7 @@ fn process_imports(cursor: &mut TreeCursor, context: &mut GoContext) {
         match node.kind() {
             "import_spec" => {
                 if let Some((alias_name, import_path)) = get_import_name(cursor, context) {
-                    let mut extra_fields = IndexMap::new();
+                    let mut extra_fields = ExtensionFields::new();
                     extra_fields.insert("package".to_string(), import_path);
                     context.create_go_tag(alias_name, "P", node, Some(extra_fields));
                 }
@@ -370,7 +370,7 @@ fn process_imports(cursor: &mut TreeCursor, context: &mut GoContext) {
                             if let Some((alias_name, import_path)) =
                                 get_import_name(cursor, context)
                             {
-                                let mut extra_fields = IndexMap::new();
+                                let mut extra_fields = ExtensionFields::new();
                                 extra_fields.insert("package".to_string(), import_path);
                                 context.create_go_tag(
                                     alias_name,
@@ -466,7 +466,7 @@ fn process_function(cursor: &mut TreeCursor, context: &mut GoContext) {
 fn process_method(cursor: &mut TreeCursor, context: &mut GoContext) {
     let node = cursor.node();
     if let Some(name) = helper::get_node_name(cursor, &context.base, &["field_identifier"]) {
-        let mut extra_fields = IndexMap::new();
+        let mut extra_fields = ExtensionFields::new();
 
         // Get receiver type - methods should only have struct field, not package
         if let Some(receiver_type) = get_method_receiver_type(cursor, context) {
@@ -915,7 +915,7 @@ fn process_field_declaration(cursor: &mut TreeCursor, context: &mut GoContext, s
 
     // Create tags for all field names
     for (name, node) in field_names {
-        let mut extra_fields = IndexMap::new();
+        let mut extra_fields = ExtensionFields::new();
         let package_name = context.get_package_name();
         if !package_name.is_empty() {
             extra_fields.insert(
@@ -954,7 +954,7 @@ fn process_method_spec_if_in_interface(cursor: &mut TreeCursor, context: &mut Go
 fn process_method_spec(cursor: &mut TreeCursor, context: &mut GoContext, interface_name: &str) {
     if let Some(name) = helper::get_node_name(cursor, &context.base, &["field_identifier"]) {
         let node = cursor.node();
-        let mut extra_fields = IndexMap::new();
+        let mut extra_fields = ExtensionFields::new();
         let package_name = context.get_package_name();
         if !package_name.is_empty() {
             extra_fields.insert(

--- a/src/parser/js.rs
+++ b/src/parser/js.rs
@@ -1,5 +1,5 @@
 use super::helper::{self, iterate_children, Break, Continue, LanguageContext, TagKindConfig};
-use indexmap::IndexMap;
+use crate::tag::ExtensionFields;
 use tree_sitter::{Node, TreeCursor};
 
 use crate::tag;
@@ -95,8 +95,8 @@ impl<'a> JsContext<'a> {
         name
     }
 
-    fn create_extension_fields(&self) -> IndexMap<String, String> {
-        let mut fields = IndexMap::new();
+    fn create_extension_fields(&self) -> ExtensionFields {
+        let mut fields = ExtensionFields::new();
 
         for (scope_type, name) in &self.scope_stack {
             match scope_type {
@@ -155,7 +155,7 @@ fn create_tag(
     kind_char: &str,
     node: Node,
     context: &mut JsContext,
-    extra_fields: Option<IndexMap<String, String>>,
+    extra_fields: Option<ExtensionFields>,
 ) {
     if name.is_empty() {
         return;
@@ -167,7 +167,7 @@ fn create_tag(
 
     let row = node.start_position().row;
     let address = helper::address_string_from_line(row, &context.base);
-    let mut extension_fields = IndexMap::new();
+    let mut extension_fields = ExtensionFields::new();
 
     if context
         .base
@@ -451,7 +451,7 @@ fn process_expression_statement(
                 let name = parts.last().unwrap().to_string();
 
                 let mut kind;
-                let mut extra = IndexMap::new();
+                let mut extra = ExtensionFields::new();
 
                 match right.kind() {
                     "function_expression" | "arrow_function" => {

--- a/src/parser/python.rs
+++ b/src/parser/python.rs
@@ -1,5 +1,5 @@
 use super::helper::{self, iterate_children, Break, Continue, LanguageContext, TagKindConfig};
-use indexmap::IndexMap;
+use crate::tag::ExtensionFields;
 use tree_sitter::{Node, TreeCursor};
 
 use crate::tag;
@@ -125,7 +125,7 @@ fn create_tag(
     kind: &str,
     node: Node,
     context: &mut PythonContext,
-    extra_fields: Option<IndexMap<String, String>>,
+    extra_fields: Option<ExtensionFields>,
 ) {
     if !context.base.tag_config.is_kind_enabled(kind) {
         return;
@@ -133,7 +133,7 @@ fn create_tag(
 
     let row = node.start_position().row;
     let address = helper::address_string_from_line(row, &context.base);
-    let mut extension_fields = IndexMap::new();
+    let mut extension_fields = ExtensionFields::new();
 
     // Kind
     if context
@@ -300,7 +300,7 @@ fn process_function_definition(
         });
 
         let kind = if is_method { "m" } else { "f" };
-        let mut extras = IndexMap::new();
+        let mut extras = ExtensionFields::new();
 
         if context
             .base
@@ -373,7 +373,7 @@ fn process_assignment_target(
 
             let kind = if is_in_function { "l" } else { "v" };
 
-            let mut extras = IndexMap::new();
+            let mut extras = ExtensionFields::new();
             if let Some(tn) = type_node {
                 extras.insert(
                     "typeref".to_string(),
@@ -410,7 +410,7 @@ fn process_assignment_target(
                     .any(|(scope_type, _)| matches!(scope_type, ScopeType::Class));
 
                 let kind = if is_method { "m" } else { "f" };
-                let mut extras = IndexMap::new();
+                let mut extras = ExtensionFields::new();
 
                 if let Some(params) = val.child_by_field_name("parameters") {
                     let params_text = context.base.node_text(&params);
@@ -482,7 +482,7 @@ fn process_import_from_statement(
                     }
 
                     if !alias.is_empty() {
-                        let mut extras = IndexMap::new();
+                        let mut extras = ExtensionFields::new();
 
                         let nameref = if module_name.is_empty() || module_name == "." {
                             format!("unknown:{}", original_name)

--- a/src/parser/rust.rs
+++ b/src/parser/rust.rs
@@ -1,5 +1,5 @@
 use super::helper::{self, LanguageContext, TagKindConfig};
-use indexmap::IndexMap;
+use crate::tag::ExtensionFields;
 use tree_sitter::{Node, TreeCursor};
 
 use crate::tag;
@@ -85,8 +85,8 @@ impl<'a> RustContext<'a> {
     }
 
     // Build extension fields based on the current scope stack
-    fn create_extension_fields(&self) -> IndexMap<String, String> {
-        let mut fields = IndexMap::new();
+    fn create_extension_fields(&self) -> ExtensionFields {
+        let mut fields = ExtensionFields::new();
         let mut module_path = Vec::new();
 
         for (scope_type, name) in &self.scope_stack {
@@ -220,7 +220,7 @@ fn create_tag(
     node: Node, // Pass the node for position info
     context: &mut RustContext,
     // Allow passing extra fields specific to the item being tagged
-    extra_fields: Option<IndexMap<String, String>>,
+    extra_fields: Option<ExtensionFields>,
 ) {
     if name.is_empty() || name == "_" {
         return; // Don't tag empty or placeholder names
@@ -233,7 +233,7 @@ fn create_tag(
 
     let row = node.start_position().row;
     let address = helper::address_string_from_line(row, &context.base);
-    let mut extension_fields = IndexMap::new();
+    let mut extension_fields = ExtensionFields::new();
 
     // Insert fields in ctags order (alphabetical by field letter, with special cases first):
 
@@ -481,7 +481,7 @@ fn process_identifiers_list(
                         &["identifier", "field_identifier"],
                     ) {
                         // Add enum/struct name context specifically for the variant tag
-                        let mut variant_fields = IndexMap::new();
+                        let mut variant_fields = ExtensionFields::new();
                         variant_fields.insert(variant_type.to_string(), name.to_owned());
                         create_tag(
                             variant_name,
@@ -522,7 +522,7 @@ fn process_impl(cursor: &mut TreeCursor, context: &mut RustContext) -> Option<(S
     let node = cursor.node();
     let (trait_name, type_name) = find_impl_names(cursor, context)?;
 
-    let mut extra_fields = IndexMap::new();
+    let mut extra_fields = ExtensionFields::new();
     let tag_name = type_name?.clone();
     let kind_char = "c";
 
@@ -591,7 +591,7 @@ fn process_function(
 ) {
     let node = cursor.node();
     if let Some(name) = helper::get_node_name(cursor, &context.base, &["identifier"]) {
-        let mut extra_fields = IndexMap::new();
+        let mut extra_fields = ExtensionFields::new();
 
         // Only get the signature string if signature field is enabled
         if context

--- a/src/parser/typescript.rs
+++ b/src/parser/typescript.rs
@@ -1,5 +1,5 @@
 use super::helper::{self, iterate_children, Break, Continue, LanguageContext, TagKindConfig};
-use indexmap::IndexMap;
+use crate::tag::ExtensionFields;
 use tree_sitter::{Node, TreeCursor};
 
 use crate::tag;
@@ -129,7 +129,7 @@ fn create_tag(
     kind: &str,
     node: Node,
     context: &mut TypeScriptContext,
-    extra_fields: Option<IndexMap<String, String>>,
+    extra_fields: Option<ExtensionFields>,
 ) {
     if !context.base.tag_config.is_kind_enabled(kind) {
         return;
@@ -137,7 +137,7 @@ fn create_tag(
 
     let row = node.start_position().row;
     let address = helper::address_string_from_line(row, &context.base);
-    let mut extension_fields = IndexMap::new();
+    let mut extension_fields = ExtensionFields::new();
 
     // Kind
     if context
@@ -383,7 +383,7 @@ fn process_method_definition(
     });
 
     if !name.is_empty() {
-        let mut extras = IndexMap::new();
+        let mut extras = ExtensionFields::new();
         if context
             .base
             .user_config
@@ -424,7 +424,7 @@ fn process_method_signature(
     });
 
     if !name.is_empty() {
-        let mut extras = IndexMap::new();
+        let mut extras = ExtensionFields::new();
         if context
             .base
             .user_config
@@ -546,7 +546,7 @@ fn process_parameter(
 
     if !name.is_empty() && !access.is_empty() {
         if !access.is_empty() {
-            let mut extras = IndexMap::new();
+            let mut extras = ExtensionFields::new();
             if context
                 .base
                 .user_config
@@ -590,7 +590,7 @@ fn process_public_field_definition(
     });
 
     if !name.is_empty() {
-        let mut extras = IndexMap::new();
+        let mut extras = ExtensionFields::new();
         if context
             .base
             .user_config
@@ -626,7 +626,7 @@ fn process_property_signature(
     });
 
     if !name.is_empty() {
-        let mut extras = IndexMap::new();
+        let mut extras = ExtensionFields::new();
         if context
             .base
             .user_config

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -3,8 +3,7 @@ use super::manifest::PluginManifest;
 use super::shared::SharedPlugin;
 use crate::config::Config;
 use crate::split_by_newlines::split_by_newlines;
-use crate::tag::Tag;
-use indexmap::IndexMap;
+use crate::tag::{ExtensionFields, Tag};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -427,7 +426,7 @@ fn convert_tags(
         .into_iter()
         .map(|t| {
             let address = format_address(source_lines, t.line);
-            let mut ext_fields = IndexMap::new();
+            let mut ext_fields = ExtensionFields::new();
             if let Some(end) = t.end_line {
                 ext_fields.insert("end".to_string(), end.to_string());
             }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -7,10 +7,65 @@
 //! across a codebase. This module handles the parsing and formatting of tags
 //! in a format compatible with Vi/Vim.
 
-use indexmap::IndexMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
+
+/// An ordered collection of ctags extension fields.
+///
+/// ctags output requires the fields to appear in a specific, stable order, so
+/// this preserves insertion order. Keys are unique: re-inserting an existing key
+/// updates its value in place rather than appending a duplicate.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ExtensionFields(Vec<(String, String)>);
+
+impl ExtensionFields {
+    pub fn new() -> Self {
+        ExtensionFields(Vec::new())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.0.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+    }
+
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.0.iter().any(|(k, _)| k == key)
+    }
+
+    // Replace an existing key's value in place (preserving its position),
+    // otherwise append.
+    pub fn insert(&mut self, key: String, value: String) {
+        if let Some(slot) = self.0.iter_mut().find(|(k, _)| *k == key) {
+            slot.1 = value;
+        } else {
+            self.0.push((key, value));
+        }
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, (String, String)> {
+        self.0.iter()
+    }
+}
+
+impl Extend<(String, String)> for ExtensionFields {
+    fn extend<T: IntoIterator<Item = (String, String)>>(&mut self, iter: T) {
+        for (k, v) in iter {
+            self.insert(k, v);
+        }
+    }
+}
+
+impl IntoIterator for ExtensionFields {
+    type Item = (String, String);
+    type IntoIter = std::vec::IntoIter<(String, String)>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
 
 /// Represents a Vi compatible tag
 ///
@@ -29,7 +84,7 @@ pub struct Tag {
     /// The tag kind
     pub kind: Option<String>,
     /// The extension fields associated with the tag
-    pub extension_fields: Option<IndexMap<String, String>>,
+    pub extension_fields: Option<ExtensionFields>,
 }
 
 impl Tag {
@@ -134,7 +189,7 @@ impl Tag {
             let module_value = fields.get("module").map(|s| s.as_str());
 
             // Count non-module keys to determine if module is the only field
-            let non_module_keys_count = fields.keys().filter(|k| *k != "module").count();
+            let non_module_keys_count = fields.iter().filter(|(k, _)| k != "module").count();
             let module_only = non_module_keys_count == 0 && module_value.is_some();
 
             // Process module field if it's the only field
@@ -237,7 +292,7 @@ pub fn parse_tag_line(line: &str) -> Option<Tag> {
 
     // Process extension fields (starting from index 3)
     if parts.len() > 3 {
-        let mut fields_map = IndexMap::new();
+        let mut fields_map = ExtensionFields::new();
 
         for field in parts.iter().skip(3) {
             // Skip empty fields
@@ -375,7 +430,7 @@ mod tests {
 
     #[test]
     fn test_bytes_with_module_only() {
-        let mut extension_fields = IndexMap::new();
+        let mut extension_fields = ExtensionFields::new();
         extension_fields.insert("module".to_string(), "example".to_string());
 
         let tag = Tag {
@@ -392,7 +447,7 @@ mod tests {
 
     #[test]
     fn test_bytes_with_non_module_field() {
-        let mut extension_fields = IndexMap::new();
+        let mut extension_fields = ExtensionFields::new();
         extension_fields.insert("implementation".to_string(), "Circle".to_string());
 
         let tag = Tag {
@@ -409,7 +464,7 @@ mod tests {
 
     #[test]
     fn test_bytes_with_module_and_implementation() {
-        let mut extension_fields = IndexMap::new();
+        let mut extension_fields = ExtensionFields::new();
         extension_fields.insert("implementation".to_string(), "Circle".to_string());
         extension_fields.insert("module".to_string(), "example".to_string());
 
@@ -429,7 +484,7 @@ mod tests {
 
     #[test]
     fn test_bytes_with_module_and_trait() {
-        let mut extension_fields = IndexMap::new();
+        let mut extension_fields = ExtensionFields::new();
         extension_fields.insert("trait".to_string(), "Shape".to_string());
         extension_fields.insert("module".to_string(), "example".to_string());
 
@@ -449,7 +504,7 @@ mod tests {
 
     #[test]
     fn test_bytes_with_multiple_extension_fields() {
-        let mut extension_fields = IndexMap::new();
+        let mut extension_fields = ExtensionFields::new();
         extension_fields.insert("trait".to_string(), "Shape".to_string());
         extension_fields.insert("implementation".to_string(), "Circle".to_string());
         extension_fields.insert("module".to_string(), "geometry".to_string());
@@ -482,7 +537,7 @@ mod tests {
             file_name: "types.rs".to_string(),
             address: "/^enum MyEnum {$/".to_string(),
             kind: Some("enum".to_string()),
-            extension_fields: Some(IndexMap::new()), // Empty IndexMap
+            extension_fields: Some(ExtensionFields::new()), // Empty ExtensionFields
         };
 
         let expected = "MyEnum\ttypes.rs\t/^enum MyEnum {$/\tenum\n";


### PR DESCRIPTION
it did not provide much functionality and was easy to replace with a new type wrapping `Vec<(String, String)>`