### PR TITLE
Avoid making copies of each line of code that is read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ the Kotlin plugin
 - Use work stealing rayon threads for processing files in parallel
 Noticably faster than the earlier thread based implementation
 - Don't pre-sort tags of each individual file
+- Stop copying every line of source code, use slices which borrow from the source instead
 
 ### Removed
 - Fallback tags query for Kotlin

--- a/src/parser/common/tree_walker.rs
+++ b/src/parser/common/tree_walker.rs
@@ -16,7 +16,7 @@ pub trait LanguageContext {
 /// Stores context during traversal
 pub struct Context<'a> {
     pub source_code: &'a str,
-    pub lines: Vec<Vec<u8>>,
+    pub lines: Vec<&'a [u8]>,
     pub file_name: Arc<str>,
     pub tags: &'a mut Vec<tag::Tag>,
     pub tag_config: &'a TagKindConfig,
@@ -44,7 +44,7 @@ pub fn generate_tags_with_config(
     language: tree_sitter::Language,
     code: &[u8],
     file_path: &str,
-    action: impl for<'a> FnOnce(&'a str, Vec<Vec<u8>>, &mut TreeCursor<'a>, &mut Vec<tag::Tag>),
+    action: impl for<'a> FnOnce(&'a str, Vec<&'a [u8]>, &mut TreeCursor<'a>, &mut Vec<tag::Tag>),
 ) -> Option<Vec<tag::Tag>> {
     let source_code = match std::str::from_utf8(code) {
         Ok(s) => s,

--- a/src/parser/cpp.rs
+++ b/src/parser/cpp.rs
@@ -103,7 +103,7 @@ struct CppContext<'a> {
 impl<'a> CppContext<'a> {
     fn new(
         source_code: &'a str,
-        lines: Vec<Vec<u8>>,
+        lines: Vec<&'a [u8]>,
         file_name: &'a str,
         tags: &'a mut Vec<tag::Tag>,
         tag_config: &'a TagKindConfig,

--- a/src/parser/go.rs
+++ b/src/parser/go.rs
@@ -185,7 +185,7 @@ struct GoContext<'a> {
 impl<'a> GoContext<'a> {
     fn new(
         source_code: &'a str,
-        lines: Vec<Vec<u8>>,
+        lines: Vec<&'a [u8]>,
         file_name: &'a str,
         tags: &'a mut Vec<tag::Tag>,
         tag_config: &'a TagKindConfig,

--- a/src/parser/helper.rs
+++ b/src/parser/helper.rs
@@ -145,7 +145,7 @@ pub fn address_string_from_line(row: usize, context: &Context) -> String {
     if row >= context.lines.len() {
         return format!("/^{}$/;", row + 1);
     }
-    let line = String::from_utf8_lossy(&context.lines[row]);
+    let line = String::from_utf8_lossy(context.lines[row]);
 
     // "/^" prefix (2) + "$/;\"" suffix (4) + slack for a few escapes.
     let mut address = String::with_capacity(line.len() + 16);

--- a/src/parser/js.rs
+++ b/src/parser/js.rs
@@ -57,7 +57,7 @@ struct JsContext<'a> {
 impl<'a> JsContext<'a> {
     fn new(
         source_code: &'a str,
-        lines: Vec<Vec<u8>>,
+        lines: Vec<&'a [u8]>,
         file_name: &'a str,
         tags: &'a mut Vec<tag::Tag>,
         tag_config: &'a TagKindConfig,

--- a/src/parser/python.rs
+++ b/src/parser/python.rs
@@ -61,7 +61,7 @@ struct PythonContext<'a> {
 impl<'a> PythonContext<'a> {
     fn new(
         source_code: &'a str,
-        lines: Vec<Vec<u8>>,
+        lines: Vec<&'a [u8]>,
         file_name: &'a str,
         tags: &'a mut Vec<tag::Tag>,
         tag_config: &'a TagKindConfig,

--- a/src/parser/rust.rs
+++ b/src/parser/rust.rs
@@ -65,7 +65,7 @@ struct RustContext<'a> {
 impl<'a> RustContext<'a> {
     fn new(
         source_code: &'a str,
-        lines: Vec<Vec<u8>>,
+        lines: Vec<&'a [u8]>,
         file_name: &'a str,
         tags: &'a mut Vec<tag::Tag>,
         tag_config: &'a TagKindConfig,

--- a/src/parser/typescript.rs
+++ b/src/parser/typescript.rs
@@ -63,7 +63,7 @@ struct TypeScriptContext<'a> {
 impl<'a> TypeScriptContext<'a> {
     fn new(
         source_code: &'a str,
-        lines: Vec<Vec<u8>>,
+        lines: Vec<&'a [u8]>,
         file_name: &'a str,
         tags: &'a mut Vec<tag::Tag>,
         tag_config: &'a TagKindConfig,

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -432,7 +432,7 @@ fn load_manifest(manifest_path: &Path, entries: &mut HashMap<String, PluginEntry
 
 fn convert_tags(
     plugin_tags: Vec<PluginTag>,
-    source_lines: &[Vec<u8>],
+    source_lines: &[&[u8]],
     file_path: &str,
     kind_letters: &HashSet<&'static str>,
 ) -> Vec<Tag> {
@@ -468,10 +468,10 @@ fn convert_tags(
     tags
 }
 
-fn format_address(lines: &[Vec<u8>], line: u32) -> String {
+fn format_address(lines: &[&[u8]], line: u32) -> String {
     let line_bytes = lines
         .get(line.saturating_sub(1) as usize)
-        .map(|v| v.as_slice())
+        .copied()
         .unwrap_or(b"");
     Tag::address_from_line(line_bytes)
 }

--- a/src/split_by_newlines.rs
+++ b/src/split_by_newlines.rs
@@ -1,40 +1,39 @@
-/// Splits a Vec<u8> into multiple vectors at newline boundaries.
+/// Splits a byte slice into line slices at newline boundaries.
 /// Handles all common line ending formats: LF (\n), CR (\r), and CRLF (\r\n).
-pub fn split_by_newlines(data: &[u8]) -> Vec<Vec<u8>> {
+///
+/// Returns slices that borrow from `data`, to avoid per-line allocation or copying
+/// of the source. The line-ending bytes themselves are excluded from each returned
+/// slice.
+pub fn split_by_newlines(data: &[u8]) -> Vec<&[u8]> {
     let mut result = Vec::new();
-    let mut current_line = Vec::new();
+    let mut line_start = 0;
     let mut i = 0;
 
     while i < data.len() {
         match data[i] {
-            // Handle CR (\r)
+            // Handle CR (\r), possibly followed by LF (CRLF)
             b'\r' => {
-                // Push the current line (without the CR)
-                result.push(current_line);
-                current_line = Vec::new();
+                result.push(&data[line_start..i]);
 
-                // Check if the next byte is LF (for CRLF)
+                // Skip the LF part of CRLF
                 if i + 1 < data.len() && data[i + 1] == b'\n' {
-                    i += 1; // Skip the LF part of CRLF
+                    i += 1;
                 }
+                line_start = i + 1;
             }
             // Handle LF (\n)
             b'\n' => {
-                // Push the current line (without the LF)
-                result.push(current_line);
-                current_line = Vec::new();
+                result.push(&data[line_start..i]);
+                line_start = i + 1;
             }
-            // Regular byte - add to current line
-            _ => {
-                current_line.push(data[i]);
-            }
+            _ => {}
         }
         i += 1;
     }
 
-    // Don't forget to push the last line if it doesn't end with a newline
-    if !current_line.is_empty() {
-        result.push(current_line);
+    // Push the last line if it doesn't end with a newline
+    if line_start < data.len() {
+        result.push(&data[line_start..]);
     }
 
     result


### PR DESCRIPTION
Use slices that borrow from the original source rather than copying each line into a Vec