### PR TITLE
Add support for files with encodings other than UTF-8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chardetng"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13de944a44b5064ee5d3a5ceccc49a41bfec50f2580e66f82e87703acdb88b53"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,9 +2288,11 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "cc",
+ "chardetng",
  "clap",
  "clap_complete",
  "dirs",
+ "encoding_rs",
  "libloading",
  "predicates 2.1.5",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ exclude = ["tests/", ".github/", "plugins/"]
 anyhow = "1"
 wasmtime = { version = "45", features = ["cranelift", "component-model"] }
 wasmtime-wasi = "45"
+encoding_rs = "0.8"
+chardetng = "1"
 clap = { version = "4.5.27", features = ["derive", "string"] }
 clap_complete = "4.5"
 dirs = "6.0.0"

--- a/src/decode_to_utf8.rs
+++ b/src/decode_to_utf8.rs
@@ -1,0 +1,32 @@
+// src/decode_to_utf8.rs
+
+//! A helper to guess and decode text files
+//!
+//! This module allows reading files in different text encodings to a standard UTF-8 string
+use chardetng::EncodingDetector;
+use encoding_rs::{Encoding, UTF_8};
+use std::borrow::Cow;
+
+/// Decode `bytes` to UTF-8, guessing the encoding when it isn't already UTF-8.
+/// Returns the text, the encoding used, and whether any bytes were replaced with U+FFFD.
+pub fn decode_to_utf8(bytes: &[u8]) -> (Cow<'_, str>, &'static Encoding, bool) {
+    // An explicit BOM at the start: decode accordingly, but strip it so it doesn't become U+FEFF.
+    if let Some((encoding, bom_len)) = Encoding::for_bom(bytes) {
+        let (text, encoding_used, had_replacements) = encoding.decode(&bytes[bom_len..]);
+        return (text, encoding_used, had_replacements);
+    }
+
+    // Already valid UTF-8 (the overwhelmingly common case): borrow, no copy.
+    if let Ok(s) = std::str::from_utf8(bytes) {
+        return (Cow::Borrowed(s), UTF_8, false);
+    }
+
+    // Guess a legacy encoding. We don't allow UTF-8 because we know at this
+    // point that `bytes` isn't a valid UTF-8.
+    let mut detector = EncodingDetector::new(chardetng::Iso2022JpDetection::Deny);
+    detector.feed(bytes, true);
+    let encoding = detector.guess(None, chardetng::Utf8Detection::Deny);
+    let (text, had_replacements) = encoding.decode_without_bom_handling(bytes);
+
+    (text, encoding, had_replacements)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ let tags = parser.parse_file(&file_path_relative_to_tag_file, &file_path, extens
 pub mod built_in_grammars;
 pub mod builtin_langs;
 pub mod config;
+pub mod decode_to_utf8;
 pub mod file_finder;
 pub mod lang_resolve;
 pub mod language_parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::process;
 mod built_in_grammars;
 mod builtin_langs;
 mod config;
+mod decode_to_utf8;
 mod file_finder;
 mod kinds_listing;
 mod lang_resolve;

--- a/src/parser/common/tree_walker.rs
+++ b/src/parser/common/tree_walker.rs
@@ -57,7 +57,7 @@ pub fn generate_tags_with_config(
         }
     };
 
-    let lines = split_by_newlines::split_by_newlines(code);
+    let lines = split_by_newlines::split_by_newlines(source_code.as_bytes());
 
     ts_parser
         .set_language(&language)

--- a/src/tag_processor.rs
+++ b/src/tag_processor.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::decode_to_utf8;
 use crate::language_parser::{LangId, LanguageParserRegistry, NameResolution};
 use crate::parser::Parser;
 use crate::tag::Tag;
@@ -230,7 +231,23 @@ impl TagProcessor {
             },
         };
 
-        let mut tags = lp.generate_tags(parser, &code, &file_path_relative, config, &file_path);
+        let (decoded, encoding, had_replacements) = decode_to_utf8::decode_to_utf8(&code);
+
+        if had_replacements {
+            eprintln!(
+                "Warning: {} contains bytes that are not valid {}; they were replaced with U+FFFD.",
+                file_path_relative,
+                encoding.name()
+            );
+        }
+
+        let mut tags = lp.generate_tags(
+            parser,
+            decoded.as_bytes(),
+            &file_path_relative,
+            config,
+            &file_path,
+        );
 
         if config.sort {
             tags.sort_unstable_by(|a, b| a.sort_cmp(b));


### PR DESCRIPTION
The previous code assumed that the file encoding should be UTF-8, skipping files that can't be decoded to UTF-8 (for instance Latin-1/ISO-8859-2, windows-1252, etc.)

This commit adds two dependencies:

- `charedetng` to guess the encoding of a file
- `encoding_rs` to decode the file with the right encoding

This will make treetags more robust and versatile, especially when used with old big code bases.